### PR TITLE
Use Message::send to write to STDOUT

### DIFF
--- a/src/bin/echo.rs
+++ b/src/bin/echo.rs
@@ -34,9 +34,7 @@ impl Node<(), Payload> for EchoNode {
         match reply.body.payload {
             Payload::Echo { echo } => {
                 reply.body.payload = Payload::EchoOk { echo };
-                serde_json::to_writer(&mut *output, &reply)
-                    .context("serialize response to init")?;
-                output.write_all(b"\n").context("write trailing newline")?;
+                reply.send(output).context("serialize response to echo")?;
             }
             Payload::EchoOk { .. } => {}
         }

--- a/src/bin/echo.rs
+++ b/src/bin/echo.rs
@@ -34,7 +34,7 @@ impl Node<(), Payload> for EchoNode {
         match reply.body.payload {
             Payload::Echo { echo } => {
                 reply.body.payload = Payload::EchoOk { echo };
-                reply.send(output).context("serialize response to echo")?;
+                reply.send(output).context("send response to echo")?;
             }
             Payload::EchoOk { .. } => {}
         }

--- a/src/bin/unique-ids.rs
+++ b/src/bin/unique-ids.rs
@@ -42,9 +42,9 @@ impl Node<(), Payload> for UniqueNode {
             Payload::Generate => {
                 let guid = format!("{}-{}", self.node, self.id);
                 reply.body.payload = Payload::GenerateOk { guid };
-                serde_json::to_writer(&mut *output, &reply)
+                reply
+                    .send(output)
                     .context("serialize response to generate")?;
-                output.write_all(b"\n").context("write trailing newline")?;
             }
             Payload::GenerateOk { .. } => {}
         }

--- a/src/bin/unique-ids.rs
+++ b/src/bin/unique-ids.rs
@@ -42,9 +42,7 @@ impl Node<(), Payload> for UniqueNode {
             Payload::Generate => {
                 let guid = format!("{}-{}", self.node, self.id);
                 reply.body.payload = Payload::GenerateOk { guid };
-                reply
-                    .send(output)
-                    .context("serialize response to generate")?;
+                reply.send(output).context("send response to generate")?;
             }
             Payload::GenerateOk { .. } => {}
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,8 +117,8 @@ where
             payload: InitPayload::InitOk,
         },
     };
-    serde_json::to_writer(&mut stdout, &reply).context("serialize response to init")?;
-    stdout.write_all(b"\n").context("write trailing newline")?;
+
+    reply.send(&mut stdout).context("send init reply")?;
 
     drop(stdin);
     let jh = std::thread::spawn(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ where
         },
     };
 
-    reply.send(&mut stdout).context("send init reply")?;
+    reply.send(&mut stdout).context("send response to init")?;
 
     drop(stdin);
     let jh = std::thread::spawn(move || {


### PR DESCRIPTION
There are inconsistencies in that sometimes methods write directly to STDOUT and sometimes use the Message::send method.

I have changed the occurrences where STDOUT was being written to directly and added appropriate anyhow contexts.
